### PR TITLE
Add pushCustomScreen

### DIFF
--- a/DebugScreen/Common/Models/Modules/ModuleType.swift
+++ b/DebugScreen/Common/Models/Modules/ModuleType.swift
@@ -13,11 +13,17 @@ enum ModuleType {
     /// Module to present alert with message
     case alert(model: AlertModel)
     /// Module to present any view controller by action button tap
-    case customScreen(_ screen: UIViewController)
-    /// Module to push any view controller onto the debug screen navigation stack
-    case pushCustomScreen(_ screen: UIViewController)
+    case customScreen(_ screen: UIViewController, method: CustomScreenPresentationMethod)
     /// Module to open local file by selected filepath
     case fileViewer(model: FileViewerModel)
     /// Module to present information table screen.
     case infoTable(model: InfoTableModel)
+}
+
+/// Defines how a custom screen should be presented from the debug menu
+enum CustomScreenPresentationMethod {
+    /// Present modally over the current screen
+    case present
+    /// Push onto the debug screen navigation stack
+    case push
 }

--- a/DebugScreen/Common/Models/Modules/ModuleType.swift
+++ b/DebugScreen/Common/Models/Modules/ModuleType.swift
@@ -14,6 +14,8 @@ enum ModuleType {
     case alert(model: AlertModel)
     /// Module to present any view controller by action button tap
     case customScreen(_ screen: UIViewController)
+    /// Module to push any view controller onto the debug screen navigation stack
+    case pushCustomScreen(_ screen: UIViewController)
     /// Module to open local file by selected filepath
     case fileViewer(model: FileViewerModel)
     /// Module to present information table screen.

--- a/DebugScreen/Flows/DebugScreenCoordinator.swift
+++ b/DebugScreen/Flows/DebugScreenCoordinator.swift
@@ -30,6 +30,8 @@ final class DebugScreenCoordinator: BaseCoordinator {
             showAlert(with: model)
         case .customScreen(let screen):
             showCustomScreen(screen)
+        case .pushCustomScreen(let screen):
+            pushCustomScreen(screen)
         case .fileViewer(let model):
             showFile(with: model)
         case .infoTable(let model):
@@ -119,6 +121,10 @@ private extension DebugScreenCoordinator {
         let view = BaseNavigationController(rootViewController: screen)
         view.modalPresentationStyle = .overFullScreen
         router.present(view)
+    }
+
+    func pushCustomScreen(_ screen: UIViewController) {
+        router.push(screen)
     }
 
     func configureActionSheetItem(with model: Action) -> UIAlertAction {

--- a/DebugScreen/Flows/DebugScreenCoordinator.swift
+++ b/DebugScreen/Flows/DebugScreenCoordinator.swift
@@ -28,10 +28,8 @@ final class DebugScreenCoordinator: BaseCoordinator {
         switch module {
         case .alert(let model):
             showAlert(with: model)
-        case .customScreen(let screen):
-            showCustomScreen(screen)
-        case .pushCustomScreen(let screen):
-            pushCustomScreen(screen)
+        case .customScreen(let screen, let method):
+            showCustomScreen(screen, method: method)
         case .fileViewer(let model):
             showFile(with: model)
         case .infoTable(let model):
@@ -117,14 +115,15 @@ private extension DebugScreenCoordinator {
         router.push(view)
     }
 
-    func showCustomScreen(_ screen: UIViewController) {
-        let view = BaseNavigationController(rootViewController: screen)
-        view.modalPresentationStyle = .overFullScreen
-        router.present(view)
-    }
-
-    func pushCustomScreen(_ screen: UIViewController) {
-        router.push(screen)
+    func showCustomScreen(_ screen: UIViewController, method: CustomScreenPresentationMethod) {
+        switch method {
+        case .present:
+            let view = BaseNavigationController(rootViewController: screen)
+            view.modalPresentationStyle = .overFullScreen
+            router.present(view)
+        case .push:
+            router.push(screen)
+        }
     }
 
     func configureActionSheetItem(with model: Action) -> UIAlertAction {

--- a/DebugScreen/Services/DebugScreenPresenterService.swift
+++ b/DebugScreen/Services/DebugScreenPresenterService.swift
@@ -45,11 +45,19 @@ public final class DebugScreenPresenterService {
         openModule(.alert(model: model))
     }
 
-    /// Show custom view controller.
+    /// Show custom view controller modally.
     /// Can be showed only when debug screen is open.
     /// - Parameter view: Screen to display.
     public func showCustomScreen(_ view: UIViewController) {
         openModule(.customScreen(view))
+    }
+
+    /// Push custom view controller onto the debug screen navigation stack.
+    /// Provides a standard back button to return to the debug menu.
+    /// Can be used only when debug screen is open.
+    /// - Parameter view: Screen to display.
+    public func pushCustomScreen(_ view: UIViewController) {
+        openModule(.pushCustomScreen(view))
     }
 
     /// Open log file.

--- a/DebugScreen/Services/DebugScreenPresenterService.swift
+++ b/DebugScreen/Services/DebugScreenPresenterService.swift
@@ -48,8 +48,8 @@ public final class DebugScreenPresenterService {
     /// Show custom view controller modally.
     /// Can be showed only when debug screen is open.
     /// - Parameter view: Screen to display.
-    public func showCustomScreen(_ view: UIViewController) {
-        openModule(.customScreen(view))
+    public func presentCustomScreen(_ view: UIViewController) {
+        openModule(.customScreen(view, method: .present))
     }
 
     /// Push custom view controller onto the debug screen navigation stack.
@@ -57,7 +57,7 @@ public final class DebugScreenPresenterService {
     /// Can be used only when debug screen is open.
     /// - Parameter view: Screen to display.
     public func pushCustomScreen(_ view: UIViewController) {
-        openModule(.pushCustomScreen(view))
+        openModule(.customScreen(view, method: .push))
     }
 
     /// Open log file.

--- a/Example/DebugScreenExample/App/DebugScreenConfiguration/Builders/ActionsSectionBuilder.swift
+++ b/Example/DebugScreenExample/App/DebugScreenConfiguration/Builders/ActionsSectionBuilder.swift
@@ -53,7 +53,7 @@ private extension ActionsSectionBuilder {
     func getOpenScreenAction() -> DebugScreenAction {
         let action: DebugScreenAction = .init(title: L10n.Actions.openScreenTitle) {
             let view = DestinationViewController()
-            DebugScreenPresenterService.shared.showCustomScreen(view)
+            DebugScreenPresenterService.shared.presentCustomScreen(view)
         }
         return action
     }

--- a/Example/DebugScreenExample/App/DebugScreenConfiguration/Builders/ActionsSectionBuilder.swift
+++ b/Example/DebugScreenExample/App/DebugScreenConfiguration/Builders/ActionsSectionBuilder.swift
@@ -18,6 +18,7 @@ final class ActionsSectionBuilder: SectionBuilder {
         let defaultAction = getAction(style: .secondary)
         let destructiveAction = getAction(style: .destructive)
         let openScreenAction = getOpenScreenAction()
+        let pushScreenAction = getPushScreenAction()
 
         let actionList = configureActionList()
 
@@ -25,7 +26,8 @@ final class ActionsSectionBuilder: SectionBuilder {
             .actionList(model: actionList),
             .action(model: defaultAction),
             .action(model: destructiveAction),
-            .action(model: openScreenAction)
+            .action(model: openScreenAction),
+            .action(model: pushScreenAction)
         ]
 
         return .init(title: L10n.Actions.header, blocks: blocks)
@@ -52,6 +54,14 @@ private extension ActionsSectionBuilder {
         let action: DebugScreenAction = .init(title: L10n.Actions.openScreenTitle) {
             let view = DestinationViewController()
             DebugScreenPresenterService.shared.showCustomScreen(view)
+        }
+        return action
+    }
+
+    func getPushScreenAction() -> DebugScreenAction {
+        let action: DebugScreenAction = .init(title: L10n.Actions.pushScreenTitle) {
+            let view = DestinationViewController()
+            DebugScreenPresenterService.shared.pushCustomScreen(view)
         }
         return action
     }

--- a/Example/DebugScreenExample/App/DebugScreenConfiguration/Builders/MenuItemsSectionBuilder.swift
+++ b/Example/DebugScreenExample/App/DebugScreenConfiguration/Builders/MenuItemsSectionBuilder.swift
@@ -35,7 +35,7 @@ private extension MenuItemsSectionBuilder {
             showsDisclosure: true
         ) {
             let view = DestinationViewController()
-            DebugScreenPresenterService.shared.showCustomScreen(view)
+            DebugScreenPresenterService.shared.presentCustomScreen(view)
         }
 
         let multilineItem = DebugScreenMenuItem(

--- a/Example/DebugScreenExample/Library/Resources/Strings/Strings.swift
+++ b/Example/DebugScreenExample/Library/Resources/Strings/Strings.swift
@@ -27,6 +27,8 @@ internal enum L10n {
     internal static let header = L10n.tr("Localizable", "Actions.header")
     /// Открытие экрана
     internal static let openScreenTitle = L10n.tr("Localizable", "Actions.openScreenTitle")
+    /// Пуш экрана
+    internal static let pushScreenTitle = L10n.tr("Localizable", "Actions.pushScreenTitle")
     /// Вспомогательное
     internal static let secondaryTitle = L10n.tr("Localizable", "Actions.secondaryTitle")
   }

--- a/Example/DebugScreenExample/Library/Resources/Strings/en.lproj/Localizable.strings
+++ b/Example/DebugScreenExample/Library/Resources/Strings/en.lproj/Localizable.strings
@@ -12,6 +12,7 @@
 "Actions.secondaryTitle" = "Secondary";
 "Actions.destructiveTitle" = "Destructive";
 "Actions.openScreenTitle" = "Open Screen";
+"Actions.pushScreenTitle" = "Push Screen";
 
 // MARK: - ActionList
 

--- a/Example/DebugScreenExample/Library/Resources/Strings/ru.lproj/Localizable.strings
+++ b/Example/DebugScreenExample/Library/Resources/Strings/ru.lproj/Localizable.strings
@@ -12,6 +12,7 @@
 "Actions.secondaryTitle" = "Вспомогательное";
 "Actions.destructiveTitle" = "Удаление";
 "Actions.openScreenTitle" = "Открытие экрана";
+"Actions.pushScreenTitle" = "Пуш экрана";
 
 // MARK: - ActionList
 


### PR DESCRIPTION
# What is done

Add pushCustomScreen() method (Push custom view controller onto the debug screen navigation stack. Provides a standard back button to return to the debug menu. Can be used only when debug screen is open. Parameter view: Screen to display.)

# How to check

DebugScreen -> Actions -> "Push Screen" button